### PR TITLE
Add some extra apk packages to allow building psycopg2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@ docs/
 Makefile
 Dockerfile
 .git
+venv
+*.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alephdata/memorious
+RUN apk add --no-cache --virtual .build-deps gcc python3-dev postgresql-dev
 COPY . /opensanctions
 RUN pip install -e /opensanctions
 ENV MEMORIOUS_CONFIG_PATH=/opensanctions/opensanctions/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "2"
+
+volumes:
+  local_postgres_data: {}
+
+services:
+  worker:
+    build: .
+    command: memorious process
+    links:
+      - postgres
+    volumes:
+      - "./build/data:/data"
+    tmpfs:
+      - "/tmp"
+    env_file:
+      - envfile.env
+
+  postgres:
+    image: postgres:11.4
+    volumes:
+      - local_postgres_data:/var/lib/postgresql/data
+    env_file:
+      - envfile.env
+
+  ui:
+    build: .
+    command: gunicorn -t 900 -w 8 -b 0.0.0.0:8000 --log-level info --log-file - memorious.ui.views:app
+    links:
+      - redis
+    volumes:
+      - "./build/data:/data"
+    tmpfs:
+      - "/tmp"
+    ports:
+      - "8000:8000"
+    env_file:
+      - envfile.env
+
+  redis:
+    image: redis:alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - ./build/redis-data:/data

--- a/envfile.env
+++ b/envfile.env
@@ -1,0 +1,8 @@
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=mysecretpassword
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=os
+MEMORIOUS_DATASTORE_URI: postgresql://postgres:mysecretpassword@postgres/os
+ARCHIVE_TYPE: file
+ARCHIVE_PATH: /data/archive


### PR DESCRIPTION
Hi! When I tried building the docker image myself, I got this error at the pip install stage:

```
Collecting psycopg2-binary>=2.7; extra == "sql" (from balkhash[sql]>=0.3.0->opensanctions==1.99)
  Downloading https://files.pythonhosted.org/packages/80/91/91911be01869fa877135946f928ed0004e62044bdd876c1e0f12e1b5fb90/psycopg2-binary-2.8.3.tar.gz (378kB)
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: running egg_info
    creating pip-egg-info/psycopg2_binary.egg-info
    writing pip-egg-info/psycopg2_binary.egg-info/PKG-INFO
    writing dependency_links to pip-egg-info/psycopg2_binary.egg-info/dependency_links.txt
    writing top-level names to pip-egg-info/psycopg2_binary.egg-info/top_level.txt
    writing manifest file 'pip-egg-info/psycopg2_binary.egg-info/SOURCES.txt'
    
    Error: pg_config executable not found.
    
    pg_config is required to build psycopg2 from source.  Please add the directory
    containing pg_config to the $PATH or specify the full executable path with the
    option:
    
        python setup.py build_ext --pg-config /path/to/pg_config build ...
    
    or with the pg_config option in 'setup.cfg'.
    
    If you prefer to avoid building psycopg2 from source, please install the PyPI
    'psycopg2-binary' package instead.
    
    For further information please check the 'doc/src/install.rst' file (also at
    <http://initd.org/psycopg/docs/install.html>).
```

Adding the packages in this PR gets rid of the error and the build succeeds. I don't know if the line I've added is ideal, it's guesswork based on the memorious image and some googling of the error message. For example I don't know what `--virtual` means.

Once it built, I tried to run it:

`docker run opensanctions memorious run un_sc_sanctions`

It soon runs into this error:

```
INFO:un_sc_sanctions.store:[un_sc_sanctions->store(balkhash_put)]: 64a18776a19c11e9bf880242ac110002
ERROR:un_sc_sanctions.store:'NoneType' object has no attribute 'upper'
Traceback (most recent call last):
  File "/memorious/memorious/logic/context.py", line 75, in execute
    return self.stage.method(self, data)
  File "/usr/lib/python3.7/site-packages/balkhash/memorious.py", line 21, in balkhash_put
    writer = get_dataset(context)
  File "/usr/lib/python3.7/site-packages/balkhash/memorious.py", line 15, in get_dataset
    return init(**config)
  File "/usr/lib/python3.7/site-packages/balkhash/__init__.py", line 5, in init
    backend = backend.upper()
AttributeError: 'NoneType' object has no attribute 'upper'
```

Am I doing something wrong? I couldn't see anything obvious in the memorious docs.