### PR TITLE
Update HMT Sanctions Data URL

### DIFF
--- a/opensanctions/config/gb_hmt_sanctions.yml
+++ b/opensanctions/config/gb_hmt_sanctions.yml
@@ -5,7 +5,7 @@ pipeline:
   init:
     method: seed
     params:
-      url: 'http://hmt-sanctions.s3.amazonaws.com/sanctionsconlist.csv'
+      url: 'https://ofsistorage.blob.core.windows.net/publishlive/ConList.csv'
     handle:
       pass: fetch
   fetch:


### PR DESCRIPTION
Update GB HMT Sanctions Data URL from the retired S3 storage to the new Azure Blob storage