### PR TITLE
Add new feature Interpol Yellow Notices

### DIFF
--- a/docs/_data/sources.yml
+++ b/docs/_data/sources.yml
@@ -6,8 +6,8 @@
   category: sanctions
   publisher:
     title: United Nations Security Council
-    url: 'https://www.un.org/en/sc/'
-  url: 'https://www.un.org/sc/suborg/en/sanctions/un-sc-consolidated-list'
+    url: "https://www.un.org/en/sc/"
+  url: "https://www.un.org/sc/suborg/en/sanctions/un-sc-consolidated-list"
   data:
     url: https://scsanctions.un.org/resources/xml/en/consolidated.xml
     format: XML
@@ -19,8 +19,8 @@
   category: pep
   publisher:
     title: WorldPresidentsDB.com
-    url: 'http://www.worldpresidentsdb.com/'
-  url: 'http://www.worldpresidentsdb.com/list/current/'
+    url: "http://www.worldpresidentsdb.com/"
+  url: "http://www.worldpresidentsdb.com/list/current/"
 
 - title: CIA World Leaders
   description: >
@@ -152,7 +152,7 @@
   slug: interpol_red_notices
   category: crime
   publisher:
-    title: Interpol
+    title: Interpol Red
     url: https://www.interpol.int/
   url: https://www.interpol.int/INTERPOL-expertise/Notices
   data:
@@ -200,3 +200,17 @@
   data:
     url: http://www.assembly.coe.int/nw/xml/AssemblyList/MP-Alpha-EN.asp?initial=A
     format: HTML
+
+- title: INTERPOL Yellow Notices
+  description: >
+    International arrest warrants published by INTERPOL with a view to
+    extradition of the wanted individuals.
+  slug: interpol_yellow_notices
+  category: researched
+  publisher:
+    title: Interpol Yellow
+    url: https://www.interpol.int/
+  url: https://www.interpol.int/INTERPOL-expertise/Notices
+  data:
+    url: https://www.interpol.int/INTERPOL-expertise/Notices
+    format: xml

--- a/opensanctions/config/interpol_yellow_notices.yml
+++ b/opensanctions/config/interpol_yellow_notices.yml
@@ -1,0 +1,51 @@
+name: interpol_yellow_notices
+description: "[OSANC] Interpol Yellow Notices"
+schedule: daily
+pipeline:
+  init:
+    method: seed
+    params:
+      url: "https://www.interpol.int/en/How-we-work/Notices/View-Yellow-Notices"
+    handle:
+      pass: fetch
+  fetch:
+    method: fetch
+    params:
+      http_rate_limit: 30
+    handle:
+      pass: index
+  index:
+    method: opensanctions.crawlers.interpol_yellow_notices:get_nationalities
+    handle:
+      pass: fetch_notices
+  fetch_notices:
+    method: fetch
+    params:
+      http_rate_limit: 30
+    handle:
+      pass: parse_nationalitywise_noticelist
+  parse_nationalitywise_noticelist:
+    method: opensanctions.crawlers.interpol_yellow_notices:parse_nationalitywise_noticelist
+    handle:
+      pass: fetch_notice
+      fetch: fetch_notices_agewise
+  fetch_notices_agewise:
+    method: fetch
+    params:
+      http_rate_limit: 30
+    handle:
+      pass: parse_noticelist
+  parse_noticelist:
+    method: opensanctions.crawlers.interpol_yellow_notices:parse_noticelist
+    handle:
+      pass: fetch_notice
+  fetch_notice:
+    method: fetch
+    params:
+      http_rate_limit: 30
+    handle:
+      pass: parse_notice
+  parse_notice:
+    method: opensanctions.crawlers.interpol_yellow_notices:parse_notice
+aggregator:
+  method: ftm_load_aleph

--- a/opensanctions/crawlers/interpol_yellow_notices.py
+++ b/opensanctions/crawlers/interpol_yellow_notices.py
@@ -1,0 +1,101 @@
+from normality import collapse_spaces, stringify
+from pprint import pformat  # noqa
+from datetime import datetime
+from ftmstore.memorious import EntityEmitter
+
+from opensanctions import constants
+
+
+SEXES = {
+    "M": constants.MALE,
+    "F": constants.FEMALE,
+}
+
+AGE_WISE_URL = "https://ws-public.interpol.int/notices/v1/yellow?ageMin={0}&ageMax={0}&resultPerPage=160"  # noqa
+AGE_NATIONALITY_WISE_URL = "https://ws-public.interpol.int/notices/v1/yellow?ageMin={0}&ageMax={0}&nationality={1}&resultPerPage=160"  # noqa
+NATIONALITY_WISE_URL = "https://ws-public.interpol.int/notices/v1/yellow?nationality={0}&resultPerPage=160"  # noqa
+
+
+def parse_date(date):
+    if date:
+        try:
+            date = datetime.strptime(date, "%Y/%m/%d")
+        except ValueError:
+            date = datetime.strptime(date, "%Y")
+        return date.date()
+
+
+def get_value(el):
+    if el is None:
+        return
+    text = stringify(el.get("value"))
+    if text is not None:
+        return collapse_spaces(text)
+
+
+def get_nationalities(context, data):
+    with context.http.rehash(data) as result:
+        doc = result.html
+        nationalities = doc.findall(
+            ".//select[@id='nationality']//option"
+        )
+        nationalities = [get_value(el) for el in nationalities]
+        for nationality in nationalities:
+            url = NATIONALITY_WISE_URL.format(nationality)
+            data["url"] = url
+            data["retry_attempt"] = 3
+            data["nationality"] = nationality
+            context.emit(data=data)
+
+
+def parse_nationalitywise_noticelist(context, data):
+    with context.http.rehash(data) as res:
+        res = res.json
+        notices = res["_embedded"]["notices"]
+        for notice in notices:
+            url = notice["_links"]["self"]["href"]
+            if context.skip_incremental(url):
+                context.emit(data={"url": url})
+        total = res["total"]
+        if int(total) > 160:
+            for age in range(18, 100):
+                url = AGE_NATIONALITY_WISE_URL.format(age, data["nationality"])
+                data["url"] = url
+                context.emit(data=data, rule="fetch")
+
+
+def parse_noticelist(context, data):
+    with context.http.rehash(data) as res:
+        res = res.json
+        notices = res["_embedded"]["notices"]
+        for notice in notices:
+            url = notice["_links"]["self"]["href"]
+            if context.skip_incremental(url):
+                context.emit(data={"url": url})
+
+
+def parse_notice(context, data):
+    with context.http.rehash(data) as res:
+        res = res.json
+        first_name = res["forename"] or ""
+        last_name = res["name"] or ""
+        dob = res["date_of_birth"]
+        nationalities = res["nationalities"]
+        place_of_birth = res["place_of_birth"]
+        gender = SEXES.get(res["sex_id"])
+        emitter = EntityEmitter(context)
+        entity = emitter.make("Person")
+        entity.make_id("INTERPOL", first_name,
+                       last_name, res["entity_id"])
+        entity.add("name", first_name + " " + last_name)
+        entity.add("firstName", first_name)
+        entity.add("lastName", last_name)
+        entity.add("nationality", nationalities)
+        entity.add("gender", gender)
+        entity.add("birthPlace", place_of_birth)
+        entity.add("birthDate", parse_date(dob))
+        entity.add("sourceUrl", res["_links"]["self"]["href"])
+        entity.add("keywords", "YELLOWNOTICE")
+        entity.add("topics", "researched")
+        emitter.emit(entity)
+        emitter.finalize()


### PR DESCRIPTION
Based on the Interpol Red Notices, fetching the yellow list of Interpol to list researched people. Also updating the source.yml file to add the yellow list and to differentiate the red from the yellow.

_**What is Interpol's Yellow Notices ?**_
A Yellow Notice is a global police alert for a missing person. It is published for victims of parental abductions, criminal abductions (kidnappings) or unexplained disappearances.

The Yellow Notice can also be used to help identify a person who is unable to identify himself or herself.

This is a valuable law enforcement tool that can increase the chances of a missing person being located, particularly if there is a possibility that the person might travel, or be taken, abroad.

_**Why is the Yellow Notice important?**_
- It gives high, international visibility to cases.
- Abducted/missing persons are flagged to border officials, making travel difficult.
- Countries can request and share critical information linked to the investigation.

_**Why it's important to fetch this list ?**_
- It helps global authorities to find researched people.
- It prevent abducted/missing persons to be found in war front.

**Changes :**
- Add **interpol_yellow_notices.py** to **crawlers/**
- Add **interpol_yellow_notices.yml** to **config/**
- Update **docs/_data/source.yml**

See also : [About Yellow Notices](https://www.interpol.int/en/How-we-work/Notices/Yellow-Notices)