### PR TITLE
The type of the cell was not handled in au_dfat_sanctions

### DIFF
--- a/opensanctions/crawlers/au_dfat_sanctions.py
+++ b/opensanctions/crawlers/au_dfat_sanctions.py
@@ -76,12 +76,10 @@ def parse(context, data):
             for header, cell in row.items():
                 if cell.ctype == 2:
                     row[header] = str(int(cell.value))
-                elif cell.ctype == 3:
-                    date = xldate_as_datetime(cell.value, xls.datemode)
-                    row[header] = date.isoformat()
                 elif cell.ctype == 0:
                     row[header] = None
-                row[header] = cell.value
+                else:
+                    row[header] = cell.value
 
             reference = clean_reference(row.get("reference"))
             references[reference].append(row)


### PR DESCRIPTION
The type of the cells wasn't handled by the script because a else statement was missing.

**Changes :**
- Delete the handling of the type 3 (datetime) (not used)
- Add else statement