### PR TITLE
Add new feature EU Committee of Regions Members and alternates

### DIFF
--- a/docs/_data/sources.yml
+++ b/docs/_data/sources.yml
@@ -6,8 +6,8 @@
   category: sanctions
   publisher:
     title: United Nations Security Council
-    url: 'https://www.un.org/en/sc/'
-  url: 'https://www.un.org/sc/suborg/en/sanctions/un-sc-consolidated-list'
+    url: "https://www.un.org/en/sc/"
+  url: "https://www.un.org/sc/suborg/en/sanctions/un-sc-consolidated-list"
   data:
     url: https://scsanctions.un.org/resources/xml/en/consolidated.xml
     format: XML
@@ -19,8 +19,8 @@
   category: pep
   publisher:
     title: WorldPresidentsDB.com
-    url: 'http://www.worldpresidentsdb.com/'
-  url: 'http://www.worldpresidentsdb.com/list/current/'
+    url: "http://www.worldpresidentsdb.com/"
+  url: "http://www.worldpresidentsdb.com/list/current/"
 
 - title: CIA World Leaders
   description: >
@@ -199,4 +199,20 @@
   url: http://www.assembly.coe.int/nw/Home-EN.asp
   data:
     url: http://www.assembly.coe.int/nw/xml/AssemblyList/MP-Alpha-EN.asp?initial=A
+    format: HTML
+
+- title: List of the members and alternates of the European Commitee of the Regions
+  description: >
+    ​The European Committee of the Regions (CoR) is the voice of regions and 
+    cities in the European Union (EU). It represents local and regional authorities 
+    across the European Union and advises on new laws that have an impact on regions 
+    and cities (70% of all EU legislation).
+  slug: eu_cor_m_a
+  category: pep
+  publisher:
+    title: European Committee of the Regions
+    url: https://cor.europa.eu/en
+  url: https://cor.europa.eu/en
+  data:
+    url: http://memberspage.cor.europa.eu/
     format: HTML

--- a/opensanctions/config/eu_cor_m_a.yml
+++ b/opensanctions/config/eu_cor_m_a.yml
@@ -1,0 +1,28 @@
+name: eu_cor_m_a
+description: "[OSANC] List of the members and alternates of the European Commitee of the Regions"
+schedule: daily
+pipeline:
+  init:
+    method: seed
+    params:
+      url: "http://memberspage.cor.europa.eu/"
+    handle:
+      pass: fetch
+  fetch:
+    method: fetch
+    handle:
+      pass: index
+  index:
+    method: opensanctions.crawlers.eu_cor_m_a:index
+    params:
+      url: "http://memberspage.cor.europa.eu/"
+    handle:
+      pass: fetch_people
+  fetch_people:
+    method: fetch
+    handle:
+      pass: parse
+  parse:
+    method: opensanctions.crawlers.eu_cor_m_a:parse
+aggregator:
+  method: ftm_load_aleph

--- a/opensanctions/crawlers/eu_cor_m_a.py
+++ b/opensanctions/crawlers/eu_cor_m_a.py
@@ -1,0 +1,98 @@
+from pprint import pprint  # noqa
+from ftmstore.memorious import EntityEmitter
+from urllib.parse import urljoin
+import requests
+
+ROOT_URL = "https://memberspage.cor.europa.eu"
+SEARCH_URL = "http://memberspage.cor.europa.eu/Search/Details/Person/"
+
+
+def parse(context, data):
+    emitter = EntityEmitter(context)
+    url = data.get("url")
+    with context.http.rehash(data) as res:
+        doc = res.html
+        divs = doc.findall('.//div[@class="regular-details"]/div')
+        image_link = "{}{}".format(ROOT_URL, divs[0].find(
+            './/img').attrib['src'])
+        infos = {}
+
+        i = divs[1].find(
+            './/ul[@class="no-bullet"]/li//i[@class="glyphicon glyphicon-phone-alt"]')
+
+        if i is not None:
+            for item in i.xpath("following-sibling::*/text()|following-sibling::text()"):
+                item = item.strip()
+                if item:
+                    infos['phone'] = item
+
+        for li in divs[1].findall('.//ul[@class="no-bullet"]/li'):
+            children = li.getchildren()
+            title = children[0]
+            if len(children) > 1:
+                if children[1].tag == 'a':
+                    infos[title.text.strip()[0:-1]] = children[1].text
+            elif title.tag == 'b':
+                for item in title.xpath("following-sibling::*/text()|following-sibling::text()"):
+                    item = item.strip()
+                    if item:
+                        infos[title.text.strip()[0:-1]] = item
+
+        first_name = infos['Full name'].split(', ')[1]
+        last_name = infos['Full name'].split(', ')[0]
+
+        person = emitter.make("Person")
+        person.make_id(url, first_name, last_name)
+        person.add('firstName', first_name)
+        person.add('lastName', last_name)
+        person.add('name', infos.pop('Full name'))
+
+        street = ''
+        if 'Street' in infos:
+            street = infos.pop('Street')
+
+        city = ''
+        if 'City' in infos:
+            city = infos.pop('City')
+
+        postal_code = ''
+        if 'Postal code' in infos:
+            postal_code = infos.pop('Postal code')
+
+        country = ''
+        if 'Country' in infos:
+            country = infos.pop('Country')
+
+        person.add('position', "{} {} {} {}".format(
+            street, city, postal_code, country))
+
+        email = 'no email'
+        if 'Emails' in infos:
+            email = infos.pop('Emails')
+
+        person.add('email', email)
+
+        phone = 'no phone'
+        if i is not None:
+            phone = infos.pop('phone')
+
+        person.add('phone', phone)
+
+        person.add('sector', infos.pop('Represented Country'))
+        person.add('sourceUrl', url)
+
+        emitter.emit(person)
+
+    emitter.finalize()
+
+
+def index(context, data):
+    with context.http.rehash(data) as res:
+        doc = res.html
+        for link in doc.xpath('//div[@class="people"]/ul[@class="no-bullet"]/li'):
+            person_url = urljoin(SEARCH_URL, link.attrib['id'][1::])
+            person = doc.xpath(
+                '//li[@id="_{}"]//ul[@class="no-bullet"]/li/a[@class="_fullname"]'.format(link.attrib['id'][1::]))[0]
+            context.log.info(
+                "Crawling person: {} ({})".format(person.text, person_url))
+            context.emit(data={"url": person_url})

--- a/opensanctions/crawlers/eu_cor_m_a.py
+++ b/opensanctions/crawlers/eu_cor_m_a.py
@@ -2,6 +2,7 @@ from pprint import pprint  # noqa
 from ftmstore.memorious import EntityEmitter
 from urllib.parse import urljoin
 import requests
+import json
 
 ROOT_URL = "https://memberspage.cor.europa.eu"
 SEARCH_URL = "http://memberspage.cor.europa.eu/Search/Details/Person/"
@@ -15,37 +16,64 @@ def parse(context, data):
         divs = doc.findall('.//div[@class="regular-details"]/div')
         image_link = "{}{}".format(ROOT_URL, divs[0].find(
             './/img').attrib['src'])
+
         infos = {}
-
-        i = divs[1].find(
-            './/ul[@class="no-bullet"]/li//i[@class="glyphicon glyphicon-phone-alt"]')
-
-        if i is not None:
-            for item in i.xpath("following-sibling::*/text()|following-sibling::text()"):
-                item = item.strip()
-                if item:
-                    infos['phone'] = item
+        infos['phone'] = []
 
         for li in divs[1].findall('.//ul[@class="no-bullet"]/li'):
             children = li.getchildren()
             title = children[0]
             if len(children) > 1:
-                if children[1].tag == 'a':
-                    infos[title.text.strip()[0:-1]] = children[1].text
-            elif title.tag == 'b':
-                for item in title.xpath("following-sibling::*/text()|following-sibling::text()"):
-                    item = item.strip()
-                    if item:
-                        infos[title.text.strip()[0:-1]] = item
+                infos[title.text.strip()[0:-1]] = []
+                for child in children:
+                    if child.tag == 'a':
+                        infos[title.text.strip()[0:-1]].append(child.text)
+                    if child.tag == 'ul':
+                        for li_in in child.findall('./li'):
+                            infos[title.text.strip()[0:-1]].append(li_in.text)
+                    if child.tag == 'b':
+                        for item in title.xpath("following-sibling::*/text()|following-sibling::text()"):
+                            item = item.strip()
+                            if item:
+                                infos[title.text.strip()[0:-1]].append(item)
+                    if child.tag == 'img':
+                        infos[title.text.strip()[
+                            0:-1]].append("image: {}{}".format(ROOT_URL, child.attrib['src']))
+            elif title.tag == 'b' or title.tag == 'i':
+                if title.tag == 'i' and not title.attrib:
+                    infos['description'] = title.text
+                else:
+                    for item in title.xpath("following-sibling::*/text()|following-sibling::text()"):
+                        item = item.strip()
+                        if item:
+                            if title.tag == 'b':
+                                infos[title.text.strip()[0:-1]] = item
+                            elif title.tag == 'i':
+                                phone_type = "phone"
+                                if title.attrib['class'] == 'fa fa-fax':
+                                    phone_type = "fax"
+                                infos['phone'].append(
+                                    "{}: {}".format(phone_type, item))
 
         first_name = infos['Full name'].split(', ')[1]
         last_name = infos['Full name'].split(', ')[0]
 
+        if 'Languages' in infos:
+            infos['Languages'] = [info.strip()
+                                  for info in infos['Languages'].split(',')]
+
         person = emitter.make("Person")
         person.make_id(url, first_name, last_name)
+
         person.add('firstName', first_name)
         person.add('lastName', last_name)
         person.add('name', infos.pop('Full name'))
+
+        description = 'no description'
+        if 'description' in infos:
+            description = infos.pop('description')
+
+        person.add('description', description)
 
         street = ''
         if 'Street' in infos:
@@ -73,12 +101,18 @@ def parse(context, data):
         person.add('email', email)
 
         phone = 'no phone'
-        if i is not None:
+        if infos['phone']:
             phone = infos.pop('phone')
 
         person.add('phone', phone)
 
         person.add('sector', infos.pop('Represented Country'))
+
+        infos['Photo'] = image_link
+
+        person.add('notes', json.dumps(
+            {key: value for key, value in infos.items()}))
+
         person.add('sourceUrl', url)
 
         emitter.emit(person)


### PR DESCRIPTION
_**What is EU Committee of Regions Members ?**_
The European Committee of the Regions (CoR) has 329 members representing local and regional authorities from all 27​ EU Member States.

Members must be democratically elected and/or hold a political mandate in their home country. Each national government proposes its regional and local representatives (members and alternates) – national delegations – who must be approved by the Council of the EU. 

CoR members are grouped according to their political affiliation – EPP, PES, Renew Europe, ECR, EA, The Greens​ – and areas of interest – commissions.

_**Why it's important to fetch this list ?**_
- It consolidates every members and alternates in the European committee of regions.

_**Changes :**_
- Add **eu_cor_m_a.py** to **crawlers/**
- Add **eu_cor_m_a.yml** to **config/**
- Update **docs/_data/source.yml**

See also : [Members' portal](https://memportal.cor.europa.eu/), [European Committee of the Regions](https://cor.europa.eu/en)